### PR TITLE
fix: Minecraft namespace prefix in texture path

### DIFF
--- a/src/consumer/itemsRenderer.ts
+++ b/src/consumer/itemsRenderer.ts
@@ -17,6 +17,9 @@ export class ItemsRenderer {
     }
 
     resolveTexture(texture: string) {
+        if (texture.startsWith('minecraft:')) {
+            texture = texture.substring(10)
+        }
         const type = texture.includes('items/') ? 'items' : (texture.includes('block/') || texture.includes('blocks/')) ? 'blocks' : 'items'
         const atlasParser = type === 'blocks' ? this.blocksAtlasParser! : this.itemsAtlasParser
         const textureInfo = atlasParser.getTextureInfo(texture.replace('block/', '').replace('blocks/', '').replace('item/', '').replace('items/', ''), this.version)!

--- a/src/consumer/itemsRenderer.ts
+++ b/src/consumer/itemsRenderer.ts
@@ -18,7 +18,7 @@ export class ItemsRenderer {
 
     resolveTexture(texture: string) {
         if (texture.startsWith('minecraft:')) {
-            texture = texture.substring(10)
+            texture = texture.slice('minecraft:'.length)
         }
         const type = texture.includes('items/') ? 'items' : (texture.includes('block/') || texture.includes('blocks/')) ? 'blocks' : 'items'
         const atlasParser = type === 'blocks' ? this.blocksAtlasParser! : this.itemsAtlasParser


### PR DESCRIPTION
### **User description**
This fixes that having a texture be prefixed with the `minecraft:` namespace would lead to a missing texture as the items are registered without namespace. (This is possible e.g. when a model is used which references the texture with a prefixed namespace like [here](https://github.com/ResilientGroup/mc-assets/blob/37367b3ed18e194bc2293b75fbf7eedea8058100/src/consumer/itemsRenderer.ts#L116))


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes handling of `minecraft:` namespace prefix in texture paths.

- Ensures textures with namespace prefix resolve correctly.

- Updates `resolveTexture` method to strip `minecraft:` prefix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>itemsRenderer.ts</strong><dd><code>Fix namespace prefix handling in texture resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/consumer/itemsRenderer.ts

<li>Added logic to strip <code>minecraft:</code> prefix from texture paths.<br> <li> Ensures compatibility with textures using namespace prefixes.<br> <li> Adjusted <code>resolveTexture</code> method for proper texture resolution.


</details>


  </td>
  <td><a href="https://github.com/zardoy/mc-assets/pull/11/files#diff-e4c02bc34ca5b7ceb7b3001fc64ad6e78de303b75509da6a3672796d919763ef">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>