### PR TITLE
feat: Allow runtime loading images from other domains

### DIFF
--- a/src/consumer/utils.ts
+++ b/src/consumer/utils.ts
@@ -7,6 +7,7 @@ export const versionToNumber = (ver: string) => {
 
 export const getLoadedImage = async (url: string) => {
     const img = new Image()
+    img.crossOrigin = 'anonymous'
     img.src = url
     if (img.complete) {
         return img


### PR DESCRIPTION
This sets the `crossOrigin` option to `anonymous` to allow loading of images from other domains (as long as they allow that) in modern browsers blocking that by default.